### PR TITLE
Add controllers

### DIFF
--- a/exchanger/lib/exchanger/api/controller.ex
+++ b/exchanger/lib/exchanger/api/controller.ex
@@ -1,0 +1,59 @@
+defmodule Exchanger.Api.Controller do
+  use Exchanger.Controller  
+
+  alias Exchanger.Conversions.Service
+  alias Exchanger.Api.Pagination, as: Pag
+
+  def list_conversions(conn) do
+    query = conn |> query_params()
+    {page, page_size} = {query[:page], query[:page_size]}
+
+    conn
+    |> response(Service.list_conversions(query),
+      # success callback function
+      fn %{items: items, total_count: total_count} ->
+        pag = Pag.build(conn.request_path, page, page_size, total_count)
+
+        # status OK, send conversions
+        {:ok, %{conversions: items, pagination: pag}}
+      end,
+
+      fn errors ->
+        {:malformed_data, %{error: "Request error", details: errors}}
+      end)
+  end
+
+  def create_conversion(conn) do
+    result = Service.create_conversion(conn.body_params)
+
+    conn
+    |> response(result,
+      fn conversion -> {:created, conversion} end,
+      fn errors -> {:unprocessable, %{error: "Validation error", details: errors}}
+    end)
+  end
+
+  def list_rates(conn) do
+    latest = Service.get_latest_rates()
+    conn |> send(:ok, %{base: latest.base, rates: latest.rates})
+  end
+
+  def handle_errors(conn, reason) do
+    conn
+    |> send(conn.status, %{error: "Request error", details: error_message(conn.status, reason)})
+  end
+
+  def not_found(conn) do
+    conn |> send(:not_found, %{error: "Resource not found"})
+  end
+
+  defp error_message(status_code, reason) do
+    case status_code do
+      400 -> "Malformed request, unexpected byte at position #{reason.exception.position}"
+      422 -> "Unprocessable entity"
+      415 -> "Unsupported media type #{reason.media_type}"
+      500 -> "Internal server error"
+      _ -> "Unknown error"
+    end
+  end
+end

--- a/exchanger/lib/exchanger/api/router.ex
+++ b/exchanger/lib/exchanger/api/router.ex
@@ -1,10 +1,8 @@
 defmodule Exchanger.Api.Router do
   use Plug.Router
   use Plug.ErrorHandler
-  import Plug.Conn
 
-  alias Exchanger.Conversions.Service
-  alias Exchanger.Api.Pagination
+  alias Exchanger.Api.Controller
 
   plug(:match)
 
@@ -16,78 +14,15 @@ defmodule Exchanger.Api.Router do
 
   plug(:dispatch)
 
-  get "/conversions" do
-    query = map_keys_to_atoms(conn.query_params)
-    page = query[:page]
-    page_size = query[:page_size]
+  get "/conversions", do: Controller.list_conversions(conn)
 
-    case Service.list_conversions(query) do
-      {:ok, %{items: items, total_count: total_count}} ->
-        pagination = Pagination.build(conn.request_path, page, page_size, total_count)
-        conn |> send(:ok, %{conversions: items, pagination: pagination})
+  post "/conversions", do: Controller.create_conversion(conn)
 
-      {:error, errors} ->
-        conn |> send(:malformed_data, %{error: "Request error", details: errors})
-    end
-  end
+  get "/conversions/rates", do: Controller.list_rates(conn)
 
-  get "/conversions/rates" do
-    latest = Service.get_latest_rates()
-    conn |> send(:ok, %{base: latest.base, rates: latest.rates})
-  end
-
-  post "/conversions" do
-    case Service.create_conversion(conn.body_params) do
-      {:ok, conversion} ->
-        conn |> send(:created, conversion)
-
-      {:error, errors} ->
-        conn |> send(:unprocessable, %{error: "Validation error", details: errors})
-    end
-  end
-
-  match _ do
-    conn |> send(:not_found, %{error: "Resource not found"})
-  end
+  match _, do: Controller.not_found(conn)
 
   @impl Plug.ErrorHandler
-  def handle_errors(conn, %{kind: _, reason: reason, stack: _}) do
-    conn
-    |> send(conn.status, %{error: "Request error", details: error_message(conn.status, reason)})
-  end
-
-  defp send(conn, code, data) when is_integer(code) do
-    conn
-    |> put_resp_content_type("application/json")
-    |> send_resp(code, Jason.encode!(data))
-  end
-
-  defp send(conn, code, data) when is_atom(code) do
-    http_codes = [
-      ok: 200,
-      created: 201,
-      not_found: 404,
-      malformed_data: 400,
-      unprocessable: 422,
-      server_error: 500,
-      error: 504
-    ]
-
-    send(conn, http_codes[code], data)
-  end
-
-  defp error_message(status_code, reason) do
-    case status_code do
-      400 -> "Malformed request, unexpected byte at position #{reason.exception.position}"
-      422 -> "Unprocessable entity"
-      415 -> "Unsupported media type #{reason.media_type}"
-      500 -> "Internal server error"
-      _ -> "Unknown error"
-    end
-  end
-
-  defp map_keys_to_atoms(map) do
-    map
-    |> Enum.reduce(%{}, fn {k, v}, m -> Map.put(m, String.to_atom(k), v) end)
-  end
+  def handle_errors(conn, %{kind: _, reason: reason, stack: _}),
+    do: Controller.handle_errors(conn, reason)
 end

--- a/exchanger/lib/exchanger/controller.ex
+++ b/exchanger/lib/exchanger/controller.ex
@@ -1,0 +1,59 @@
+defmodule Exchanger.Controller do
+  import Plug.Conn
+
+  defmacro __using__(_opts) do
+    quote location: :keep do
+      alias Exchanger.Controller
+
+      def send(conn, code, data), do:
+        Controller.send(conn, code, data)
+
+      def response(conn, result, success_fn, error_fn), do:
+        Controller.response(conn, result, success_fn, error_fn)
+
+      def body_params(conn), do:
+        Controller.map_keys_to_atoms(conn.body_params)
+
+      def query_params(conn), do:
+        Controller.map_keys_to_atoms(conn.query_params)
+    end
+  end
+
+  def response(conn, result, success_fn, error_fn) do
+    case result do
+      {:ok, content} ->
+        {status_code, content} = success_fn.(content)
+        conn |> send(status_code, content)
+
+      {:error, errors} ->
+        {status_code, content} = error_fn.(errors)
+        conn |> send(status_code, content)
+    end
+  end
+
+  def send(conn, code, data) when is_atom(code) do
+    http_codes = [
+      ok: 200,
+      created: 201,
+      not_found: 404,
+      malformed_data: 400,
+      unprocessable: 422,
+      server_error: 500,
+      error: 504
+    ]
+
+    send(conn, http_codes[code], data)
+  end
+  
+  def send(conn, code, data) when is_integer(code) do
+    conn
+    |> put_resp_content_type("application/json")
+    |> send_resp(code, Jason.encode!(data))
+  end
+
+  def map_keys_to_atoms(map) do
+    map
+    |> Enum.reduce(%{}, fn {k, v}, m -> Map.put(m, String.to_atom(k), v) end)
+  end
+end
+

--- a/exchanger/lib/exchanger/conversions/service.ex
+++ b/exchanger/lib/exchanger/conversions/service.ex
@@ -16,13 +16,12 @@ defmodule Exchanger.Conversions.Service do
   alias Exchanger.Conversions.Conversion
   alias Exchanger.Conversions.Rates
 
-  alias :mnesia, as: Mnesia
-
   @doc """
   Inserts a new conversion into the table; returns errors
   if the validation has failed.
 
   Returns a tuple with either `{:ok, conversion}` or `{:error, errors}`.
+
   """
   def create_conversion(%{} = data) do
     changeset = Conversion.changeset(%Conversion{}, data)
@@ -136,10 +135,10 @@ defmodule Exchanger.Conversions.Service do
     {page_size, offset} = page_params(params)
 
     fields = [:id, :user_id, :from, :to, :amount, :amount_conv, :rate, :inserted_at]
+    user_id = if uid = params[:user_id] do String.to_integer(uid) else nil end
 
     by_user =
-      if uid = params[:user_id] do
-        user_id = String.to_integer(uid)
+      if user_id do
         dynamic([c], c.user_id == ^user_id)
       else
         true
@@ -153,7 +152,7 @@ defmodule Exchanger.Conversions.Service do
       |> limit(^page_size)
       |> Repo.all()
 
-    %{items: items, total_count: total_count(by_user)}
+    %{items: items, total_count: total_count(user_id)}
   end
 
   defp map_errors(errors) do
@@ -192,6 +191,9 @@ defmodule Exchanger.Conversions.Service do
     end
   end
 
+  # perhaps all of these methods below could be turned into public functions
+  # on a more specialized module like Service.Paginated, in
+  # order to be fully testable
   defp page_params(%{} = params) do
     p_size = params[:page_size]
     p = params[:page]
@@ -213,9 +215,26 @@ defmodule Exchanger.Conversions.Service do
     {page_size, offset}
   end
 
-  defp total_count(by_user) do
+  defp total_count(user_id) when is_nil(user_id) do
     # mnesia doesn't have the count(*) equivalent as in SQL
-    # but this should do the job
-    Mnesia.table_info(:conversion, :size)
+    # but this should do the trick...
+    :ets.select_count(:conversion, [
+      {
+        {:_, :_, :_, :_, :_, :_, :_, :_, :_, :_},
+        [], # anything matches
+        [true]}
+    ])
+  end
+
+  defp total_count(user_id) do
+    :ets.select_count(:conversion, [
+      {
+        # table fields match spec, $1 is the user_id
+        {:_, :_, :"$1", :_, :_, :_, :_, :_, :_, :_},
+        # when user_id == 1...
+        [{:==, :"$1", user_id}],
+        # we expect the match to be true, then count it
+        [true]}
+    ])
   end
 end

--- a/exchanger/lib/exchanger/conversions/service.ex
+++ b/exchanger/lib/exchanger/conversions/service.ex
@@ -16,6 +16,8 @@ defmodule Exchanger.Conversions.Service do
   alias Exchanger.Conversions.Conversion
   alias Exchanger.Conversions.Rates
 
+  alias :mnesia, as: Mnesia
+
   @doc """
   Inserts a new conversion into the table; returns errors
   if the validation has failed.
@@ -212,12 +214,8 @@ defmodule Exchanger.Conversions.Service do
   end
 
   defp total_count(by_user) do
-    # unfortunately, mnesia doesn't have the count(*) equivalent as in SQL
-    length(
-      Conversion
-      |> select([c], c.id)
-      |> where(^by_user)
-      |> Repo.all()
-    )
+    # mnesia doesn't have the count(*) equivalent as in SQL
+    # but this should do the job
+    Mnesia.table_info(:conversion, :size)
   end
 end

--- a/exchanger/mix.exs
+++ b/exchanger/mix.exs
@@ -42,7 +42,7 @@ defmodule Exchanger.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger],
+      extra_applications: [:logger, :mnesia],
       mod: {Exchanger.Application, []}
     ]
   end


### PR DESCRIPTION
Making some improvements:

- Add new `Exchanger.Controller` module
- Use the `Exchanger.Controller` on `Exchanger.Api.Controller`

This represents the same concept of using a controller application layer, as seen on Phoenix.